### PR TITLE
Used switch-case in main loop, fixed Makefile, and pointers

### DIFF
--- a/Game/Makefile
+++ b/Game/Makefile
@@ -3,7 +3,7 @@ OPTS = -Wall -O2
 all: CasualMockSkirmish
 
 CasualMockSkirmish: dragon.o dwarf.o goblin.o grunt.o knight.o mammoth.o ogre.o print.o skirmish.o sorcerer.o start.o troll.o user_input.o warrior.o wolf.o
-    g++ dragon.o dwarf.o goblin.o grunt.o knight.o mammoth.o ogre.o print.o skirmish.o sorcerer.o start.o troll.o user_input.o warrior.o wolf.o -o CasualMockSkirmish
+	g++ dragon.o dwarf.o goblin.o grunt.o knight.o mammoth.o ogre.o print.o skirmish.o sorcerer.o start.o troll.o user_input.o warrior.o wolf.o -o CasualMockSkirmish
 	strip CasualMockSkirmish
 
 dragon.o:
@@ -34,7 +34,7 @@ skirmish.o:
 	g++ ${OPTS} -c skirmish.cpp
 
 sorcerer.o:
-    g++ ${OPTS} -c sorcerer.cpp
+	g++ ${OPTS} -c sorcerer.cpp
 
 start.o:
 	g++ ${OPTS} -c start.cpp
@@ -52,5 +52,5 @@ wolf.o:
 	g++ ${OPTS} -c wolf.cpp
 
 clean:
-    rm CasualMockSkirmish dragon.o dwarf.o goblin.o grunt.o knight.o mammoth.o ogre.o print.o skirmish.o sorcerer.o start.o troll.o user_input.o warrior.o wolf.o
+	rm CasualMockSkirmish dragon.o dwarf.o goblin.o grunt.o knight.o mammoth.o ogre.o print.o skirmish.o sorcerer.o start.o troll.o user_input.o warrior.o wolf.o
 

--- a/Game/skirmish.cpp
+++ b/Game/skirmish.cpp
@@ -82,6 +82,7 @@ void start_skirmish(std::vector<Warrior*> team_red, std::vector<Warrior*> team_b
 
                 // Remove warrior from defending team if they died.
                 if (!team_blue[random_blue_warrior]->is_alive()) {
+                    delete(team_blue[random_blue_warrior]);
                     team_blue.erase(team_blue.begin() + random_blue_warrior);
                 }
 
@@ -127,6 +128,7 @@ void start_skirmish(std::vector<Warrior*> team_red, std::vector<Warrior*> team_b
 
                 // Remove warrior from defending team if they died.
                 if (!team_red[random_red_warrior]->is_alive()) {
+                    delete(team_red[random_red_warrior]);
                     team_red.erase(team_red.begin() + random_red_warrior);
                 }
 

--- a/Game/start.cpp
+++ b/Game/start.cpp
@@ -122,39 +122,23 @@ int main() {
                 print();
                 break;
             } case 5: { // 1 dragon vs 13 dwarves
-                // Initialize dragon for team red.
-                Dragon red_dragon_smaug = Dragon("Smaug");
-
-                // Initialize 13 dwarves for team blue.
-                Dwarf blue_dwarf_dwalin = Dwarf("Dwalin");
-                Dwarf blue_dwarf_balin  = Dwarf("Balin");
-                Dwarf blue_dwarf_kili   = Dwarf("Kili");
-                Dwarf blue_dwarf_fili   = Dwarf("Fili");
-                Dwarf blue_dwarf_dori   = Dwarf("Dori");
-                Dwarf blue_dwarf_nori   = Dwarf("Nori");
-                Dwarf blue_dwarf_ori    = Dwarf("Ori");
-                Dwarf blue_dwarf_oin    = Dwarf("Oin");
-                Dwarf blue_dwarf_gloin  = Dwarf("Gloin");
-                Dwarf blue_dwarf_bifur  = Dwarf("Bifur");
-                Dwarf blue_dwarf_bofur  = Dwarf("Bofur");
-                Dwarf blue_dwarf_bombur = Dwarf("Bombur");
-                Dwarf blue_dwarf_thorin = Dwarf("Thorin");
-
                 // Initialize each team.
-                team_red  = { &red_dragon_smaug };
+                team_red  = { new Dragon("Smaug") };
+				// 13 dwarves for team blue.
                 team_blue = {
-                    &blue_dwarf_dwalin,
-                    &blue_dwarf_balin,
-                    &blue_dwarf_kili,
-                    &blue_dwarf_fili,
-                    &blue_dwarf_dori,
-                    &blue_dwarf_nori,
-                    &blue_dwarf_oin,
-                    &blue_dwarf_gloin,
-                    &blue_dwarf_bifur,
-                    &blue_dwarf_bofur,
-                    &blue_dwarf_bombur,
-                    &blue_dwarf_thorin
+                    new Dwarf("Dwalin"),
+                    new Dwarf("Balin"),
+                    new Dwarf("Kili"),
+                    new Dwarf("Fili"),
+                    new Dwarf("Dori"),
+                    new Dwarf("Nori"),
+                    new Dwarf("Ori"),
+                    new Dwarf("Oin"),
+                    new Dwarf("Gloin"),
+                    new Dwarf("Bifur"),
+                    new Dwarf("Bofur"),
+                    new Dwarf("Bombur"),
+                    new Dwarf("Thorin")
                 };
 
                 // Start skirmish simulation.
@@ -163,18 +147,14 @@ int main() {
                 print();
                 break;
             } case 6: { // 1 dwarf + 1 grunt + 1 troll vs 1 goblin + 1 ogre
-                // Initialize dwarf, grunt, and troll for team red.
-                Dwarf red_dwarf_thorin = Dwarf("Thorin");
-                Grunt red_grunt_bilbo  = Grunt("Bilbo");
-                Troll red_troll_bruz   = Troll("Bruz");
-
-                // Initialize goblin and ogre for team blue.
-                Goblin blue_goblin_grinnah = Goblin("Grinnah");
-                Ogre blue_ogre_ozoc        = Ogre("Ozoc");
-
-                // Initialize each team.
-                team_red  = { &red_dwarf_thorin, &red_grunt_bilbo, &red_troll_bruz };
-                team_blue = { &blue_goblin_grinnah, &blue_ogre_ozoc };
+                // Dwarf, grunt, and troll for team red.
+                team_red  = {
+                    new Dwarf("Thorin"),
+                    new Grunt("Bilbo"),
+                    new Troll("Bruz")
+                };
+                // Goblin and ogre for team blue.
+                team_blue = { new Goblin("Grinnah"), new Ogre("Ozoc") };
 
                 // Start skirmish simulation.
                 print();
@@ -183,29 +163,18 @@ int main() {
                 break;
             } case 7: { // 5 knights vs 3 wolves
                 // Initialize 5 knights for team red.
-                Knight red_knight_peregrin = Knight("Peregrin");
-                Knight red_knight_elessar  = Knight("Elessar");
-                Knight red_knight_aragorn  = Knight("Aragorn");
-                Knight red_knight_hakon    = Knight("Hakon");
-                Knight red_knight_emund    = Knight("Emund");
-
-                // Initialize 3 wolves for team blue.
-                Wolf blue_wolf_harog  = Wolf("Harog");
-                Wolf blue_wolf_harach = Wolf("Harach");
-                Wolf blue_wolf_ulku   = Wolf("Ulku");
-
-                // Initialize each team.
                 team_red  = {
-                    &red_knight_peregrin,
-                    &red_knight_elessar,
-                    &red_knight_aragorn,
-                    &red_knight_hakon,
-                    &red_knight_emund
+                    new Knight("Peregrin"),
+                    new Knight("Elessar"),
+                    new Knight("Aragorn"),
+                    new Knight("Hakon"),
+                    new Knight("Emund")
                 };
+                // 3 wolves for team blue.
                 team_blue = {
-                    &blue_wolf_harog,
-                    &blue_wolf_harach,
-                    &blue_wolf_ulku
+                    new Wolf("Harog"),
+                    new Wolf("Harach"),
+                    new Wolf("Ulku")
                 };
 
                 // Start skirmish simulation.
@@ -214,16 +183,9 @@ int main() {
                 print();
                 break;
             } case 8: { // 1 mammoth vs 2 dragons
-                // Initialize 1 mammoth for team red.
-                Mammoth red_mammoth_mumak = Mammoth("Mumak");
-
-                // Initialize 2 dragons for team blue.
-                Dragon blue_dragon_scatha = Dragon("Scatha");
-                Dragon blue_dragon_gostir = Dragon("Gostir");
-
                 // Initialize each team.
-                team_red  = { &red_mammoth_mumak };
-                team_blue = { &blue_dragon_gostir };
+                team_red  = { new Mammoth("Mumak") };
+                team_blue = { new Dragon("Scatha"), new Dragon("Gostir") };
 
                 // Start skirmish simulation.
                 print();
@@ -232,27 +194,17 @@ int main() {
                 break;
             } case 9: { // 4 sorcerers vs 2 knights + 1 wolf
                 // Initialize 4 sorcerers for team red.
-                Sorcerer red_sorcerer_merlin    = Sorcerer("Merlin");
-                Sorcerer red_sorcerer_nicolas   = Sorcerer("Nicolas");
-                Sorcerer red_sorcerer_durion    = Sorcerer("Durion");
-                Sorcerer red_sorcerer_cassandra = Sorcerer("Cassandra");
-
-                // Initialize 2 knights and 1 wolf for team blue.
-                Knight blue_knight_peregrin = Knight("Peregrin");
-                Knight blue_knight_elessar  = Knight("Elessar");
-                Wolf blue_wolf_harog        = Wolf("Harog");
-
-                // Initialize each team.
                 team_red  = {
-                    &red_sorcerer_merlin,
-                    &red_sorcerer_nicolas,
-                    &red_sorcerer_durion,
-                    &red_sorcerer_cassandra
+                    new Sorcerer("Merlin"),
+                    new Sorcerer("Nicolas"),
+                    new Sorcerer("Durion"),
+                    new Sorcerer("Cassandra")
                 };
+                // 2 knights and 1 wolf for team blue.
                 team_blue = {
-                    &blue_knight_peregrin,
-                    &blue_knight_elessar,
-                    &blue_wolf_harog
+                    new Knight("Peregrin"),
+                    new Knight("Elessar"),
+                    new Wolf("Harog")
                 };
 
                 // Start skirmish simulation.

--- a/Game/start.cpp
+++ b/Game/start.cpp
@@ -51,13 +51,9 @@ int main() {
         // Determine option selected.
         switch (choice = get_option(10)) {
             case 1: { // 1 grunt vs 1 grunt
-                // Initialize 1 grunt for each team.
-                Grunt red_grunt_billy  = Grunt("Billy");
-                Grunt blue_grunt_tasha = Grunt("Tasha");
-
                 // Initialize each team.
-                team_red  = { &red_grunt_billy };
-                team_blue = { &blue_grunt_tasha };
+                team_red  = { new Grunt("Billy") };
+                team_blue = { new Grunt("Tasha") };
 
                 // Start skirmish simulation.
                 print();
@@ -65,15 +61,15 @@ int main() {
                 print();
 				break;
             } case 2: { // 2 grunts vs 2 grunts
-                // Initialize two grunts for each team.
-                Grunt red_grunt_billy   = Grunt("Billy");
-                Grunt red_grunt_tasha   = Grunt("Tasha");
-                Grunt blue_grunt_sam    = Grunt("Sam");
-                Grunt blue_grunt_bessie = Grunt("Bessie");
-
-                // Initialize each team.
-                team_red  = { &red_grunt_billy, &red_grunt_tasha };
-                team_blue = { &blue_grunt_sam, &blue_grunt_bessie };
+                // Initialize two grunts for each team
+                team_red  = {
+                    new Grunt("Billy"),
+                    new Grunt("Tasha")
+                };
+                team_blue = {
+                    new Grunt("Sam"),
+                    new Grunt("Bessie")
+                };
 
                 // Start skirmish simulation.
                 print();
@@ -81,26 +77,16 @@ int main() {
                 print();
                 break;
             } case 3: { // 4 goblins vs 2 dwarves
-                // Initialize 4 goblins for team red.
-                Goblin red_goblin_azog      = Goblin("Azog");
-                Goblin red_goblin_bolg      = Goblin("Bolg");
-                Goblin red_goblin_golfimbul = Goblin("Golfimbul");
-                Goblin red_goblin_yazneg    = Goblin("Yazneg");
-
-                // Initialize 2 dwarves for team blue.
-                Dwarf blue_dwarf_bifur = Dwarf("Bifur");
-                Dwarf blue_dwarf_bofur = Dwarf("Bofur");
-
-                // Initialize each team.
+                // Initialize 4 goblins for team red
                 team_red = {
-                    &red_goblin_azog,
-                    &red_goblin_bolg,
-                    &red_goblin_golfimbul,
-                    &red_goblin_yazneg
+                    new Goblin("Azog"),
+                    new Goblin("Bolg"),
+                    new Goblin("Golfimbul"),
+                    new Goblin("Yazneg")
                 };
-                team_blue = {
-                    &blue_dwarf_bifur,
-                    &blue_dwarf_bofur
+                team_blue = { // And 2 dwarves for team blue
+                    new Dwarf("Bifur"),
+                    new Dwarf("Bofur")
                 };
 
                 // Start skirmish simulation.
@@ -110,41 +96,24 @@ int main() {
                 break;
             } case 4: { // 5 ogres vs 9 trolls
                 // Initialize 5 ogres for team red.
-                Ogre red_ogre_dozug    = Ogre("Dozug");
-                Ogre red_ogre_grizikur = Ogre("Grizikur");
-                Ogre red_ogre_iuzug    = Ogre("Iuzug");
-                Ogre red_ogre_glezakag = Ogre("Glezakag");
-                Ogre red_ogre_krezar   = Ogre("Krezar");
-
-                // Initialize 9 trolls for team blue.
-                Troll blue_troll_tom     = Troll("Tom");
-                Troll blue_troll_bert    = Troll("Bert");
-                Troll blue_troll_william = Troll("William");
-                Troll blue_troll_torog   = Troll("Torog");
-                Troll blue_troll_rogash  = Troll("Rogash");
-                Troll blue_troll_dingal  = Troll("Dingal");
-                Troll blue_troll_bill    = Troll("Bill");
-                Troll blue_troll_ronald  = Troll("Ronald");
-                Troll blue_troll_bolmug  = Troll("Bolmug");
-
-                // Initialize each team.
                 team_red  = {
-                    &red_ogre_dozug,
-                    &red_ogre_grizikur,
-                    &red_ogre_iuzug,
-                    &red_ogre_glezakag,
-                    &red_ogre_krezar
+                    new Ogre("Dozug"),
+                    new Ogre("Grizikur"),
+                    new Ogre("Iuzug"),
+                    new Ogre("Glezakag"),
+                    new Ogre("Krezar")
                 };
+                // Initialize 9 trolls for team blue.
                 team_blue = {
-                    &blue_troll_tom,
-                    &blue_troll_bert,
-                    &blue_troll_william,
-                    &blue_troll_torog,
-                    &blue_troll_rogash,
-                    &blue_troll_dingal,
-                    &blue_troll_bill,
-                    &blue_troll_ronald,
-                    &blue_troll_bolmug
+                    new Troll("Tom"),
+                    new Troll("Bert"),
+                    new Troll("William"),
+                    new Troll("Torog"),
+                    new Troll("Rogash"),
+                    new Troll("Dingal"),
+                    new Troll("Bill"),
+                    new Troll("Ronald"),
+                    new Troll("Bolmug")
                 };
 
                 // Start skirmish simulation.

--- a/Game/start.cpp
+++ b/Game/start.cpp
@@ -16,9 +16,9 @@
 #include <ctime>
 #include <vector>
 
-static void print_title();
+static void print_title(void);
 static void print_scenario(std::string optionNumber, std::string teamRed, std::string teamBlue);
-static void print_quit();
+static void print_quit(void);
 
 int main() {
     // Set new random seed for each compile time.
@@ -45,190 +45,258 @@ int main() {
         print_quit();
         print();
 
-        // Get and validate choice input.
-        choice = get_option(10);
+        std::vector<Warrior *> team_red;
+		std::vector<Warrior *> team_blue;
 
         // Determine option selected.
-        if (choice == 1) { // 1 grunt vs 1 grunt
-            // Initialize 1 grunt for each team.
-            Grunt red_grunt_billy  = Grunt("Billy");
-            Grunt blue_grunt_tasha = Grunt("Tasha");
+        switch (choice = get_option(10)) {
+            case 1: { // 1 grunt vs 1 grunt
+                // Initialize 1 grunt for each team.
+                Grunt red_grunt_billy  = Grunt("Billy");
+                Grunt blue_grunt_tasha = Grunt("Tasha");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_grunt_billy };
-            std::vector<Warrior*> team_blue { &blue_grunt_tasha };
+                // Initialize each team.
+                team_red  = { &red_grunt_billy };
+                team_blue = { &blue_grunt_tasha };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 2) { // 2 grunts vs 2 grunts
-            // Initialize two grunts for each team.
-            Grunt red_grunt_billy   = Grunt("Billy");
-            Grunt red_grunt_tasha   = Grunt("Tasha");
-            Grunt blue_grunt_sam    = Grunt("Sam");
-            Grunt blue_grunt_bessie = Grunt("Bessie");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+				break;
+            } case 2: { // 2 grunts vs 2 grunts
+                // Initialize two grunts for each team.
+                Grunt red_grunt_billy   = Grunt("Billy");
+                Grunt red_grunt_tasha   = Grunt("Tasha");
+                Grunt blue_grunt_sam    = Grunt("Sam");
+                Grunt blue_grunt_bessie = Grunt("Bessie");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_grunt_billy, &red_grunt_tasha };
-            std::vector<Warrior*> team_blue { &blue_grunt_sam, &blue_grunt_bessie };
+                // Initialize each team.
+                team_red  = { &red_grunt_billy, &red_grunt_tasha };
+                team_blue = { &blue_grunt_sam, &blue_grunt_bessie };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 3) { // 4 goblins vs 2 dwarves
-            // Initialize 4 goblins for team red.
-            Goblin red_goblin_azog      = Goblin("Azog");
-            Goblin red_goblin_bolg      = Goblin("Bolg");
-            Goblin red_goblin_golfimbul = Goblin("Golfimbul");
-            Goblin red_goblin_yazneg    = Goblin("Yazneg");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 3: { // 4 goblins vs 2 dwarves
+                // Initialize 4 goblins for team red.
+                Goblin red_goblin_azog      = Goblin("Azog");
+                Goblin red_goblin_bolg      = Goblin("Bolg");
+                Goblin red_goblin_golfimbul = Goblin("Golfimbul");
+                Goblin red_goblin_yazneg    = Goblin("Yazneg");
 
-            // Initialize 2 dwarves for team blue.
-            Dwarf blue_dwarf_bifur = Dwarf("Bifur");
-            Dwarf blue_dwarf_bofur = Dwarf("Bofur");
+                // Initialize 2 dwarves for team blue.
+                Dwarf blue_dwarf_bifur = Dwarf("Bifur");
+                Dwarf blue_dwarf_bofur = Dwarf("Bofur");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_goblin_azog, &red_goblin_bolg, &red_goblin_golfimbul, &red_goblin_yazneg };
-            std::vector<Warrior*> team_blue { &blue_dwarf_bifur, &blue_dwarf_bofur };
+                // Initialize each team.
+                team_red = {
+                    &red_goblin_azog,
+                    &red_goblin_bolg,
+                    &red_goblin_golfimbul,
+                    &red_goblin_yazneg
+                };
+                team_blue = {
+                    &blue_dwarf_bifur,
+                    &blue_dwarf_bofur
+                };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 4) { // 5 ogres vs 9 trolls
-            // Initialize 5 ogres for team red.
-            Ogre red_ogre_dozug    = Ogre("Dozug");
-            Ogre red_ogre_grizikur = Ogre("Grizikur");
-            Ogre red_ogre_iuzug    = Ogre("Iuzug");
-            Ogre red_ogre_glezakag = Ogre("Glezakag");
-            Ogre red_ogre_krezar   = Ogre("Krezar");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 4: { // 5 ogres vs 9 trolls
+                // Initialize 5 ogres for team red.
+                Ogre red_ogre_dozug    = Ogre("Dozug");
+                Ogre red_ogre_grizikur = Ogre("Grizikur");
+                Ogre red_ogre_iuzug    = Ogre("Iuzug");
+                Ogre red_ogre_glezakag = Ogre("Glezakag");
+                Ogre red_ogre_krezar   = Ogre("Krezar");
 
-            // Initialize 9 trolls for team blue.
-            Troll blue_troll_tom     = Troll("Tom");
-            Troll blue_troll_bert    = Troll("Bert");
-            Troll blue_troll_william = Troll("William");
-            Troll blue_troll_torog   = Troll("Torog");
-            Troll blue_troll_rogash  = Troll("Rogash");
-            Troll blue_troll_dingal  = Troll("Dingal");
-            Troll blue_troll_bill    = Troll("Bill");
-            Troll blue_troll_ronald  = Troll("Ronald");
-            Troll blue_troll_bolmug  = Troll("Bolmug");
+                // Initialize 9 trolls for team blue.
+                Troll blue_troll_tom     = Troll("Tom");
+                Troll blue_troll_bert    = Troll("Bert");
+                Troll blue_troll_william = Troll("William");
+                Troll blue_troll_torog   = Troll("Torog");
+                Troll blue_troll_rogash  = Troll("Rogash");
+                Troll blue_troll_dingal  = Troll("Dingal");
+                Troll blue_troll_bill    = Troll("Bill");
+                Troll blue_troll_ronald  = Troll("Ronald");
+                Troll blue_troll_bolmug  = Troll("Bolmug");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_ogre_dozug, &red_ogre_grizikur, &red_ogre_iuzug, &red_ogre_glezakag, &red_ogre_krezar };
-            std::vector<Warrior*> team_blue { &blue_troll_tom, &blue_troll_bert, &blue_troll_william, &blue_troll_torog, &blue_troll_rogash, &blue_troll_dingal, &blue_troll_bill, &blue_troll_ronald, &blue_troll_bolmug };
+                // Initialize each team.
+                team_red  = {
+                    &red_ogre_dozug,
+                    &red_ogre_grizikur,
+                    &red_ogre_iuzug,
+                    &red_ogre_glezakag,
+                    &red_ogre_krezar
+                };
+                team_blue = {
+                    &blue_troll_tom,
+                    &blue_troll_bert,
+                    &blue_troll_william,
+                    &blue_troll_torog,
+                    &blue_troll_rogash,
+                    &blue_troll_dingal,
+                    &blue_troll_bill,
+                    &blue_troll_ronald,
+                    &blue_troll_bolmug
+                };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 5) { // 1 dragon vs 13 dwarves
-            // Initialize dragon for team red.
-            Dragon red_dragon_smaug = Dragon("Smaug");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 5: { // 1 dragon vs 13 dwarves
+                // Initialize dragon for team red.
+                Dragon red_dragon_smaug = Dragon("Smaug");
 
-            // Initialize 13 dwarves for team blue.
-            Dwarf blue_dwarf_dwalin = Dwarf("Dwalin");
-            Dwarf blue_dwarf_balin  = Dwarf("Balin");
-            Dwarf blue_dwarf_kili   = Dwarf("Kili");
-            Dwarf blue_dwarf_fili   = Dwarf("Fili");
-            Dwarf blue_dwarf_dori   = Dwarf("Dori");
-            Dwarf blue_dwarf_nori   = Dwarf("Nori");
-            Dwarf blue_dwarf_ori    = Dwarf("Ori");
-            Dwarf blue_dwarf_oin    = Dwarf("Oin");
-            Dwarf blue_dwarf_gloin  = Dwarf("Gloin");
-            Dwarf blue_dwarf_bifur  = Dwarf("Bifur");
-            Dwarf blue_dwarf_bofur  = Dwarf("Bofur");
-            Dwarf blue_dwarf_bombur = Dwarf("Bombur");
-            Dwarf blue_dwarf_thorin = Dwarf("Thorin");
+                // Initialize 13 dwarves for team blue.
+                Dwarf blue_dwarf_dwalin = Dwarf("Dwalin");
+                Dwarf blue_dwarf_balin  = Dwarf("Balin");
+                Dwarf blue_dwarf_kili   = Dwarf("Kili");
+                Dwarf blue_dwarf_fili   = Dwarf("Fili");
+                Dwarf blue_dwarf_dori   = Dwarf("Dori");
+                Dwarf blue_dwarf_nori   = Dwarf("Nori");
+                Dwarf blue_dwarf_ori    = Dwarf("Ori");
+                Dwarf blue_dwarf_oin    = Dwarf("Oin");
+                Dwarf blue_dwarf_gloin  = Dwarf("Gloin");
+                Dwarf blue_dwarf_bifur  = Dwarf("Bifur");
+                Dwarf blue_dwarf_bofur  = Dwarf("Bofur");
+                Dwarf blue_dwarf_bombur = Dwarf("Bombur");
+                Dwarf blue_dwarf_thorin = Dwarf("Thorin");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_dragon_smaug };
-            std::vector<Warrior*> team_blue { &blue_dwarf_dwalin, &blue_dwarf_balin, &blue_dwarf_kili, &blue_dwarf_fili, &blue_dwarf_dori, &blue_dwarf_nori, &blue_dwarf_oin, &blue_dwarf_gloin, &blue_dwarf_bifur, &blue_dwarf_bofur, &blue_dwarf_bombur, &blue_dwarf_thorin };
+                // Initialize each team.
+                team_red  = { &red_dragon_smaug };
+                team_blue = {
+                    &blue_dwarf_dwalin,
+                    &blue_dwarf_balin,
+                    &blue_dwarf_kili,
+                    &blue_dwarf_fili,
+                    &blue_dwarf_dori,
+                    &blue_dwarf_nori,
+                    &blue_dwarf_oin,
+                    &blue_dwarf_gloin,
+                    &blue_dwarf_bifur,
+                    &blue_dwarf_bofur,
+                    &blue_dwarf_bombur,
+                    &blue_dwarf_thorin
+                };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 6) { // 1 dwarf + 1 grunt + 1 troll vs 1 goblin + 1 ogre
-            // Initialize dwarf, grunt, and troll for team red.
-            Dwarf red_dwarf_thorin = Dwarf("Thorin");
-            Grunt red_grunt_bilbo  = Grunt("Bilbo");
-            Troll red_troll_bruz   = Troll("Bruz");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 6: { // 1 dwarf + 1 grunt + 1 troll vs 1 goblin + 1 ogre
+                // Initialize dwarf, grunt, and troll for team red.
+                Dwarf red_dwarf_thorin = Dwarf("Thorin");
+                Grunt red_grunt_bilbo  = Grunt("Bilbo");
+                Troll red_troll_bruz   = Troll("Bruz");
 
-            // Initialize goblin and ogre for team blue.
-            Goblin blue_goblin_grinnah = Goblin("Grinnah");
-            Ogre blue_ogre_ozoc        = Ogre("Ozoc");
+                // Initialize goblin and ogre for team blue.
+                Goblin blue_goblin_grinnah = Goblin("Grinnah");
+                Ogre blue_ogre_ozoc        = Ogre("Ozoc");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_dwarf_thorin, &red_grunt_bilbo, &red_troll_bruz };
-            std::vector<Warrior*> team_blue { &blue_goblin_grinnah, &blue_ogre_ozoc };
+                // Initialize each team.
+                team_red  = { &red_dwarf_thorin, &red_grunt_bilbo, &red_troll_bruz };
+                team_blue = { &blue_goblin_grinnah, &blue_ogre_ozoc };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 7) { // 5 knights vs 3 wolves
-            // Initialize 5 knights for team red.
-            Knight red_knight_peregrin = Knight("Peregrin");
-            Knight red_knight_elessar  = Knight("Elessar");
-            Knight red_knight_aragorn  = Knight("Aragorn");
-            Knight red_knight_hakon    = Knight("Hakon");
-            Knight red_knight_emund    = Knight("Emund");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 7: { // 5 knights vs 3 wolves
+                // Initialize 5 knights for team red.
+                Knight red_knight_peregrin = Knight("Peregrin");
+                Knight red_knight_elessar  = Knight("Elessar");
+                Knight red_knight_aragorn  = Knight("Aragorn");
+                Knight red_knight_hakon    = Knight("Hakon");
+                Knight red_knight_emund    = Knight("Emund");
 
-            // Initialize 3 wolves for team blue.
-            Wolf blue_wolf_harog  = Wolf("Harog");
-            Wolf blue_wolf_harach = Wolf("Harach");
-            Wolf blue_wolf_ulku   = Wolf("Ulku");
+                // Initialize 3 wolves for team blue.
+                Wolf blue_wolf_harog  = Wolf("Harog");
+                Wolf blue_wolf_harach = Wolf("Harach");
+                Wolf blue_wolf_ulku   = Wolf("Ulku");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_knight_peregrin, &red_knight_elessar, &red_knight_aragorn, &red_knight_hakon, &red_knight_emund };
-            std::vector<Warrior*> team_blue { &blue_wolf_harog, &blue_wolf_harach, &blue_wolf_ulku };
+                // Initialize each team.
+                team_red  = {
+                    &red_knight_peregrin,
+                    &red_knight_elessar,
+                    &red_knight_aragorn,
+                    &red_knight_hakon,
+                    &red_knight_emund
+                };
+                team_blue = {
+                    &blue_wolf_harog,
+                    &blue_wolf_harach,
+                    &blue_wolf_ulku
+                };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 8) { // 1 mammoth vs 2 dragons
-            // Initialize 1 mammoth for team red.
-            Mammoth red_mammoth_mumak = Mammoth("Mumak");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 8: { // 1 mammoth vs 2 dragons
+                // Initialize 1 mammoth for team red.
+                Mammoth red_mammoth_mumak = Mammoth("Mumak");
 
-            // Initialize 2 dragons for team blue.
-            Dragon blue_dragon_scatha = Dragon("Scatha");
-            Dragon blue_dragon_gostir = Dragon("Gostir");
+                // Initialize 2 dragons for team blue.
+                Dragon blue_dragon_scatha = Dragon("Scatha");
+                Dragon blue_dragon_gostir = Dragon("Gostir");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_mammoth_mumak };
-            std::vector<Warrior*> team_blue { &blue_dragon_gostir };
+                // Initialize each team.
+                team_red  = { &red_mammoth_mumak };
+                team_blue = { &blue_dragon_gostir };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice == 9) { // 4 sorcerers vs 2 knights + 1 wolf
-            // Initialize 4 sorcerers for team red.
-            Sorcerer red_sorcerer_merlin    = Sorcerer("Merlin");
-            Sorcerer red_sorcerer_nicolas   = Sorcerer("Nicolas");
-            Sorcerer red_sorcerer_durion    = Sorcerer("Durion");
-            Sorcerer red_sorcerer_cassandra = Sorcerer("Cassandra");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } case 9: { // 4 sorcerers vs 2 knights + 1 wolf
+                // Initialize 4 sorcerers for team red.
+                Sorcerer red_sorcerer_merlin    = Sorcerer("Merlin");
+                Sorcerer red_sorcerer_nicolas   = Sorcerer("Nicolas");
+                Sorcerer red_sorcerer_durion    = Sorcerer("Durion");
+                Sorcerer red_sorcerer_cassandra = Sorcerer("Cassandra");
 
-            // Initialize 2 knights and 1 wolf for team blue.
-            Knight blue_knight_peregrin = Knight("Peregrin");
-            Knight blue_knight_elessar  = Knight("Elessar");
-            Wolf blue_wolf_harog        = Wolf("Harog");
+                // Initialize 2 knights and 1 wolf for team blue.
+                Knight blue_knight_peregrin = Knight("Peregrin");
+                Knight blue_knight_elessar  = Knight("Elessar");
+                Wolf blue_wolf_harog        = Wolf("Harog");
 
-            // Initialize each team.
-            std::vector<Warrior*> team_red  { &red_sorcerer_merlin, &red_sorcerer_nicolas, &red_sorcerer_durion, &red_sorcerer_cassandra };
-            std::vector<Warrior*> team_blue { &blue_knight_peregrin, &blue_knight_elessar, &blue_wolf_harog };
+                // Initialize each team.
+                team_red  = {
+                    &red_sorcerer_merlin,
+                    &red_sorcerer_nicolas,
+                    &red_sorcerer_durion,
+                    &red_sorcerer_cassandra
+                };
+                team_blue = {
+                    &blue_knight_peregrin,
+                    &blue_knight_elessar,
+                    &blue_wolf_harog
+                };
 
-            // Start skirmish simulation.
-            print();
-            start_skirmish(team_red, team_blue);
-            print();
-        } else if (choice < 1 || choice >= 10) {
-            // End game.
-            print();
-            print("Bye.");
+                // Start skirmish simulation.
+                print();
+                start_skirmish(team_red, team_blue);
+                print();
+                break;
+            } default: {
+                // End game.
+                print();
+                print("Bye.");
+                break;
+            }
         }
     } while (choice < 10);
 
@@ -240,7 +308,7 @@ int main() {
  * @brief print_title prints title header of simulation game.
  */
 
-static void print_title() {
+static void print_title(void) {
     print("************************", MAGENTA);
     print("* ", MAGENTA, false);
     print("Casual Mock Skirmish", DARK_RED, false);
@@ -267,8 +335,9 @@ static void print_scenario(std::string optionNumber, std::string teamRed, std::s
  * @brief print_quit prints quit option.
  */
 
-static void print_quit() {
+static void print_quit(void) {
     print("10", YELLOW, false);
     print(" - ", DARK_WHITE, false);
     print("Quit", MAGENTA);
 }
+

--- a/Game/warrior.cpp
+++ b/Game/warrior.cpp
@@ -9,6 +9,16 @@ Warrior::Warrior(std::string warrior_type, std::string warrior_name, unsigned in
     , attack_damage(damage_amount) { }
 // ===========================================================================================================================
 
+// Destructor ================================================================================================================
+// Main
+Warrior::~Warrior(void) {
+    type = "";
+    name = "";
+    health = 0;
+    attack_damage = 0;
+}
+// ===========================================================================================================================
+
 // Mutator(s) ============================================
 // Health (Receive Damage)
 void Warrior::receive_damage(unsigned int damage_amount) {
@@ -22,22 +32,22 @@ void Warrior::receive_damage(unsigned int damage_amount) {
 
 // Accessor(s) ==================================
 // Warrior Type
-std::string Warrior::get_type() const {
+std::string Warrior::get_type(void) const {
     return type;
 }
 
 // Warrior Individual Name
-std::string Warrior::get_name() const {
+std::string Warrior::get_name(void) const {
     return name;
 }
 
 // Health Amount
-unsigned int Warrior::get_health() const {
+unsigned int Warrior::get_health(void) const {
     return health;
 }
 
 // Damage Amount Per Attack
-unsigned int Warrior::get_attack_damage() const {
+unsigned int Warrior::get_attack_damage(void) const {
     return attack_damage;
 }
 // ==============================================
@@ -56,7 +66,7 @@ bool Warrior::attack(Warrior* opponent) const {
 }
 
 // Alive Verification
-bool Warrior::is_alive() const {
+bool Warrior::is_alive(void) const {
     return health > 0;
 }
 // =============================================

--- a/Game/warrior.h
+++ b/Game/warrior.h
@@ -9,13 +9,14 @@
 
 class Warrior : private Entity {
     public:
+        virtual ~Warrior(void);
         void receive_damage(unsigned int damage_amount) override;                                                              // Health (Receive Damage) Mutator
-        std::string get_type() const;                                                                                          // Warrior Type Accessor
-        std::string get_name() const;                                                                                          // Warrior Individual Name Accessor
-        unsigned int get_health() const;                                                                                       // Health Amount Accessor
-        unsigned int get_attack_damage() const;                                                                                // Damage Amount Per Attack Accessor
-        bool attack(Warrior* opponent) const;                                                                                  // Attack Opponent
-        bool is_alive() const override;                                                                                        // Alive Verification
+        std::string get_type(void) const;                                                                                          // Warrior Type Accessor
+        std::string get_name(void) const;                                                                                          // Warrior Individual Name Accessor
+        unsigned int get_health(void) const;                                                                                       // Health Amount Accessor
+        unsigned int get_attack_damage(void) const;                                                                                // Damage Amount Per Attack Accessor
+        bool attack(Warrior* opponent) const;                                                                                      // Attack Opponent
+        bool is_alive(void) const override;                                                                                        // Alive Verification
     protected:
         Warrior(std::string warrior_type, std::string warrior_name, unsigned int health_capacity, unsigned int damage_amount); // Main Constructor
     private:


### PR DESCRIPTION
I thought a switch-case statement would be more appropriate in `main()`'s do-while loop for the menu. I think it is QtCreator that forcefully insists on spaces, instead of tabs? I really don't like that, but I suppose it's a matter of opinion. I used spaces consistently in the source files, since they already had spaces, but the `Makefile` must use tabs. Running "make" on the newest commit gave me "Missing separator, Stop", because of the spaces. It's alright though.

When initializing the red and blue team vectors, I got rid of the unnecessary variables, and just constructed Warriors in the initializations themselves with `new` operator. These objects are `delete`-d in the `start_skirmish()` function. I also added a basic destructor to the Warrior class.